### PR TITLE
feat: add support for systemd

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ requirements:
     - jansson
     - sphinx
     - ply
+    - libsystemd0
     - lua-luaposix
     - libuuid
     - ncurses


### PR DESCRIPTION
This should add libsystemd0 as a dependency on the host so that we can hopefully have support for it - I'm guessing that flux will detect it on build.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
